### PR TITLE
7.x 1.x css

### DIFF
--- a/css/stanford_jumpstart_home.css
+++ b/css/stanford_jumpstart_home.css
@@ -301,16 +301,27 @@
 .stanford-jumpstart-home-palm.style-custom-styles-dark #block-bean-jumpstart-homepage-tall-banner .border-simple img {
   background-color: #282724;
 }
+/* line 296, ../sass/stanford_jumpstart_home.scss */
+.stanford-jumpstart-home-palm.style-custom-styles-dark .site-main-menu .navbar .nav > .active > a,
+.stanford-jumpstart-home-palm.style-custom-styles-dark .site-main-menu .navbar .nav > .active > a:hover,
+.stanford-jumpstart-home-palm.style-custom-styles-dark .site-main-menu .navbar .nav > .active > a:focus,
+.stanford-jumpstart-home-palm.style-custom-styles-dark .site-main-menu .navbar .nav > li > a:focus,
+.stanford-jumpstart-home-palm.style-custom-styles-dark .site-main-menu .navbar .nav > li > a:hover,
+.stanford-jumpstart-home-palm.style-custom-styles-dark .site-main-menu .navbar .nav > .active-trail > a {
+  color: #282724;
+  background: #fbfbf9;
+  border: 0;
+}
 
-/* line 292, ../sass/stanford_jumpstart_home.scss */
+/* line 304, ../sass/stanford_jumpstart_home.scss */
 .stanford-jumpstart-home-palm.style-custom-styles-light .navbar {
   background: #f8f7f2;
 }
-/* line 295, ../sass/stanford_jumpstart_home.scss */
+/* line 307, ../sass/stanford_jumpstart_home.scss */
 .stanford-jumpstart-home-palm.style-custom-styles-light #block-bean-jumpstart-homepage-tall-banner .border-simple img {
   background-color: #f8f7f2;
 }
-/* line 304, ../sass/stanford_jumpstart_home.scss */
+/* line 316, ../sass/stanford_jumpstart_home.scss */
 .stanford-jumpstart-home-palm.style-custom-styles-light .site-main-menu .navbar .nav > .active > a,
 .stanford-jumpstart-home-palm.style-custom-styles-light .site-main-menu .navbar .nav > .active > a:hover,
 .stanford-jumpstart-home-palm.style-custom-styles-light .site-main-menu .navbar .nav > .active > a:focus,
@@ -319,24 +330,47 @@
 .stanford-jumpstart-home-palm.style-custom-styles-light .site-main-menu .navbar .nav > .active-trail > a {
   color: #333333;
   background: #e9e6df;
+  border: 0;
 }
 
-/* line 311, ../sass/stanford_jumpstart_home.scss */
+/* line 324, ../sass/stanford_jumpstart_home.scss */
 .stanford-jumpstart-home-palm.style-custom-styles-plain .navbar {
   background: #e9e9e9;
 }
-/* line 314, ../sass/stanford_jumpstart_home.scss */
+/* line 327, ../sass/stanford_jumpstart_home.scss */
 .stanford-jumpstart-home-palm.style-custom-styles-plain #block-bean-jumpstart-homepage-tall-banner .border-simple img {
   background-color: #e9e9e9;
 }
+/* line 336, ../sass/stanford_jumpstart_home.scss */
+.stanford-jumpstart-home-palm.style-custom-styles-plain .site-main-menu .navbar .nav > .active > a,
+.stanford-jumpstart-home-palm.style-custom-styles-plain .site-main-menu .navbar .nav > .active > a:hover,
+.stanford-jumpstart-home-palm.style-custom-styles-plain .site-main-menu .navbar .nav > .active > a:focus,
+.stanford-jumpstart-home-palm.style-custom-styles-plain .site-main-menu .navbar .nav > li > a:focus,
+.stanford-jumpstart-home-palm.style-custom-styles-plain .site-main-menu .navbar .nav > li > a:hover,
+.stanford-jumpstart-home-palm.style-custom-styles-plain .site-main-menu .navbar .nav > .active-trail > a {
+  color: white;
+  background: #333333;
+  border: 0;
+}
 
-/* line 319, ../sass/stanford_jumpstart_home.scss */
+/* line 344, ../sass/stanford_jumpstart_home.scss */
 .stanford-jumpstart-home-palm.style-custom-styles-rich .navbar {
   background: #d5d0c0;
 }
-/* line 322, ../sass/stanford_jumpstart_home.scss */
+/* line 347, ../sass/stanford_jumpstart_home.scss */
 .stanford-jumpstart-home-palm.style-custom-styles-rich #block-bean-jumpstart-homepage-tall-banner .border-simple img {
   background-color: #d5d0c0;
+}
+/* line 356, ../sass/stanford_jumpstart_home.scss */
+.stanford-jumpstart-home-palm.style-custom-styles-rich .site-main-menu .navbar .nav > .active > a,
+.stanford-jumpstart-home-palm.style-custom-styles-rich .site-main-menu .navbar .nav > .active > a:hover,
+.stanford-jumpstart-home-palm.style-custom-styles-rich .site-main-menu .navbar .nav > .active > a:focus,
+.stanford-jumpstart-home-palm.style-custom-styles-rich .site-main-menu .navbar .nav > li > a:focus,
+.stanford-jumpstart-home-palm.style-custom-styles-rich .site-main-menu .navbar .nav > li > a:hover,
+.stanford-jumpstart-home-palm.style-custom-styles-rich .site-main-menu .navbar .nav > .active-trail > a {
+  color: #fbfbf9;
+  background: #5e3032;
+  border: 0;
 }
 
 /** LAYOUT: SERRA ************************
@@ -346,56 +380,56 @@
 	- Two-column mission text blocks 
 	- Three blocks
 ******************************************/
-/* line 337, ../sass/stanford_jumpstart_home.scss */
+/* line 374, ../sass/stanford_jumpstart_home.scss */
 .stanford-jumpstart-home-serra .site-main-menu, .stanford-jumpstart-home-serra .navbar {
   background: transparent;
 }
-/* line 340, ../sass/stanford_jumpstart_home.scss */
+/* line 377, ../sass/stanford_jumpstart_home.scss */
 .stanford-jumpstart-home-serra .main {
   padding-top: 0;
 }
-/* line 343, ../sass/stanford_jumpstart_home.scss */
+/* line 380, ../sass/stanford_jumpstart_home.scss */
 .stanford-jumpstart-home-serra .site-main-menu {
   border: 0;
 }
-/* line 346, ../sass/stanford_jumpstart_home.scss */
+/* line 383, ../sass/stanford_jumpstart_home.scss */
 .stanford-jumpstart-home-serra .main-top {
   padding-top: 2em;
   margin-bottom: 2em;
 }
-/* line 350, ../sass/stanford_jumpstart_home.scss */
+/* line 387, ../sass/stanford_jumpstart_home.scss */
 .stanford-jumpstart-home-serra .mission-block {
   font-size: 1.3em;
   line-height: 1.4em;
 }
-/* line 354, ../sass/stanford_jumpstart_home.scss */
+/* line 391, ../sass/stanford_jumpstart_home.scss */
 .stanford-jumpstart-home-serra #block-bean-jumpstart-info-text-block {
   margin-left: 16%;
 }
 @media (max-width: 767px) {
-  /* line 354, ../sass/stanford_jumpstart_home.scss */
+  /* line 391, ../sass/stanford_jumpstart_home.scss */
   .stanford-jumpstart-home-serra #block-bean-jumpstart-info-text-block {
     margin-left: 0;
   }
 }
 
-/* line 362, ../sass/stanford_jumpstart_home.scss */
+/* line 399, ../sass/stanford_jumpstart_home.scss */
 .stanford-jumpstart-home-serra.style-custom-styles-bright .main-top {
   border-bottom: 1px solid #53284f;
 }
-/* line 365, ../sass/stanford_jumpstart_home.scss */
+/* line 402, ../sass/stanford_jumpstart_home.scss */
 .stanford-jumpstart-home-serra.style-custom-styles-bright .main-top, .stanford-jumpstart-home-serra.style-custom-styles-bright .site-main-menu, .stanford-jumpstart-home-serra.style-custom-styles-bright .header {
   background: #53284f;
   color: white;
 }
-/* line 372, ../sass/stanford_jumpstart_home.scss */
+/* line 409, ../sass/stanford_jumpstart_home.scss */
 .stanford-jumpstart-home-serra.style-custom-styles-bright .main-top .more-link a,
 .stanford-jumpstart-home-serra.style-custom-styles-bright .main-top a.more-link,
 .stanford-jumpstart-home-serra.style-custom-styles-bright .main-top .big-text,
 .stanford-jumpstart-home-serra.style-custom-styles-bright .main-top .infotext {
   color: #ffce49;
 }
-/* line 378, ../sass/stanford_jumpstart_home.scss */
+/* line 415, ../sass/stanford_jumpstart_home.scss */
 .stanford-jumpstart-home-serra.style-custom-styles-bright .main-top .more-link a:hover,
 .stanford-jumpstart-home-serra.style-custom-styles-bright .main-top .more-link a:focus,
 .stanford-jumpstart-home-serra.style-custom-styles-bright .main-top a.more-link:hover,
@@ -404,23 +438,23 @@
   text-decoration: underline;
 }
 
-/* line 384, ../sass/stanford_jumpstart_home.scss */
+/* line 421, ../sass/stanford_jumpstart_home.scss */
 .stanford-jumpstart-home-serra.style-custom-styles-cardinal .main-top {
   border-bottom: 1px solid #8c1515;
 }
-/* line 387, ../sass/stanford_jumpstart_home.scss */
+/* line 424, ../sass/stanford_jumpstart_home.scss */
 .stanford-jumpstart-home-serra.style-custom-styles-cardinal .main-top, .stanford-jumpstart-home-serra.style-custom-styles-cardinal .site-main-menu, .stanford-jumpstart-home-serra.style-custom-styles-cardinal .header {
   background: #8c1515;
   color: white;
 }
-/* line 394, ../sass/stanford_jumpstart_home.scss */
+/* line 431, ../sass/stanford_jumpstart_home.scss */
 .stanford-jumpstart-home-serra.style-custom-styles-cardinal .main-top .more-link a,
 .stanford-jumpstart-home-serra.style-custom-styles-cardinal .main-top a.more-link,
 .stanford-jumpstart-home-serra.style-custom-styles-cardinal .main-top .big-text,
 .stanford-jumpstart-home-serra.style-custom-styles-cardinal .main-top .infotext {
   color: white;
 }
-/* line 400, ../sass/stanford_jumpstart_home.scss */
+/* line 437, ../sass/stanford_jumpstart_home.scss */
 .stanford-jumpstart-home-serra.style-custom-styles-cardinal .main-top .more-link a:hover,
 .stanford-jumpstart-home-serra.style-custom-styles-cardinal .main-top .more-link a:focus,
 .stanford-jumpstart-home-serra.style-custom-styles-cardinal .main-top a.more-link:hover,
@@ -429,23 +463,23 @@
   text-decoration: underline;
 }
 
-/* line 406, ../sass/stanford_jumpstart_home.scss */
+/* line 443, ../sass/stanford_jumpstart_home.scss */
 .stanford-jumpstart-home-serra.style-custom-styles-contrast .main-top {
   border-bottom: 1px solid transparent;
 }
-/* line 409, ../sass/stanford_jumpstart_home.scss */
+/* line 446, ../sass/stanford_jumpstart_home.scss */
 .stanford-jumpstart-home-serra.style-custom-styles-contrast .main-top, .stanford-jumpstart-home-serra.style-custom-styles-contrast .site-main-menu, .stanford-jumpstart-home-serra.style-custom-styles-contrast .header {
   background: #333333;
   color: white;
 }
-/* line 416, ../sass/stanford_jumpstart_home.scss */
+/* line 453, ../sass/stanford_jumpstart_home.scss */
 .stanford-jumpstart-home-serra.style-custom-styles-contrast .main-top .more-link a,
 .stanford-jumpstart-home-serra.style-custom-styles-contrast .main-top a.more-link,
 .stanford-jumpstart-home-serra.style-custom-styles-contrast .main-top .big-text,
 .stanford-jumpstart-home-serra.style-custom-styles-contrast .main-top .infotext {
   color: #b3995d;
 }
-/* line 422, ../sass/stanford_jumpstart_home.scss */
+/* line 459, ../sass/stanford_jumpstart_home.scss */
 .stanford-jumpstart-home-serra.style-custom-styles-contrast .main-top .more-link a:hover,
 .stanford-jumpstart-home-serra.style-custom-styles-contrast .main-top .more-link a:focus,
 .stanford-jumpstart-home-serra.style-custom-styles-contrast .main-top a.more-link:hover,
@@ -454,38 +488,38 @@
   text-decoration: underline;
 }
 
-/* line 428, ../sass/stanford_jumpstart_home.scss */
+/* line 465, ../sass/stanford_jumpstart_home.scss */
 .stanford-jumpstart-home-serra.style-custom-styles-dark .main-top {
   border-bottom: 1px solid #232220;
 }
-/* line 431, ../sass/stanford_jumpstart_home.scss */
+/* line 468, ../sass/stanford_jumpstart_home.scss */
 .stanford-jumpstart-home-serra.style-custom-styles-dark .main-top, .stanford-jumpstart-home-serra.style-custom-styles-dark .site-main-menu, .stanford-jumpstart-home-serra.style-custom-styles-dark .header {
   background: #282724;
 }
 
-/* line 436, ../sass/stanford_jumpstart_home.scss */
+/* line 473, ../sass/stanford_jumpstart_home.scss */
 .stanford-jumpstart-home-serra.style-custom-styles-light .main-top {
   border-bottom: 1px solid #e9e6df;
 }
-/* line 439, ../sass/stanford_jumpstart_home.scss */
+/* line 476, ../sass/stanford_jumpstart_home.scss */
 .stanford-jumpstart-home-serra.style-custom-styles-light .main-top, .stanford-jumpstart-home-serra.style-custom-styles-light .site-main-menu, .stanford-jumpstart-home-serra.style-custom-styles-light .header {
   background: #f8f7f2;
 }
 
-/* line 444, ../sass/stanford_jumpstart_home.scss */
+/* line 481, ../sass/stanford_jumpstart_home.scss */
 .stanford-jumpstart-home-serra.style-custom-styles-plain .main-top {
   border-bottom: 1px solid transparent;
 }
-/* line 447, ../sass/stanford_jumpstart_home.scss */
+/* line 484, ../sass/stanford_jumpstart_home.scss */
 .stanford-jumpstart-home-serra.style-custom-styles-plain .main-top, .stanford-jumpstart-home-serra.style-custom-styles-plain .site-main-menu, .stanford-jumpstart-home-serra.style-custom-styles-plain .header {
   background: white;
 }
 
-/* line 452, ../sass/stanford_jumpstart_home.scss */
+/* line 489, ../sass/stanford_jumpstart_home.scss */
 .stanford-jumpstart-home-serra.style-custom-styles-rich .main-top {
   border-bottom: 1px solid #d5d0c0;
 }
-/* line 455, ../sass/stanford_jumpstart_home.scss */
+/* line 492, ../sass/stanford_jumpstart_home.scss */
 .stanford-jumpstart-home-serra.style-custom-styles-rich .main-top, .stanford-jumpstart-home-serra.style-custom-styles-rich .site-main-menu, .stanford-jumpstart-home-serra.style-custom-styles-rich .header {
   background: #d5d0c0;
 }

--- a/sass/stanford_jumpstart_home.scss
+++ b/sass/stanford_jumpstart_home.scss
@@ -287,6 +287,18 @@
 	#block-bean-jumpstart-homepage-tall-banner .border-simple img {
 		background-color: $dark_clr-header-bkg;
 	}
+	.site-main-menu {
+	    .navbar .nav > .active > a, 
+	    .navbar .nav > .active > a:hover, 
+	    .navbar .nav > .active > a:focus, 
+	    .navbar .nav > li > a:focus, 
+	    .navbar .nav > li > a:hover,
+	    .navbar .nav > .active-trail > a {
+	        color: $dark_clr-header-bkg;
+	        background: $dark_clr-menu-text-hvr;
+	        border: 0;
+	    }
+	}
 }
 .stanford-jumpstart-home-palm.style-custom-styles-light {
 	.navbar {
@@ -304,6 +316,7 @@
 	    .navbar .nav > .active-trail > a {
 	        color: $light_clr-menu-text-hvr;
 	        background: $light_clr-menu-link-border;
+	        border: 0;
 	    }
 	}
 }
@@ -314,6 +327,18 @@
 	#block-bean-jumpstart-homepage-tall-banner .border-simple img {
 		background-color: $plain_clr-well-bkg;
 	}
+	.site-main-menu {
+	    .navbar .nav > .active > a, 
+	    .navbar .nav > .active > a:hover, 
+	    .navbar .nav > .active > a:focus, 
+	    .navbar .nav > li > a:focus, 
+	    .navbar .nav > li > a:hover,
+	    .navbar .nav > .active-trail > a {
+	        color: $plain_clr-page-bkg;
+	        background: $plain_clr-menu-text-hvr;
+	        border: 0;
+	    }
+	}
 }
 .stanford-jumpstart-home-palm.style-custom-styles-rich {
 	.navbar {
@@ -321,6 +346,18 @@
 	}
 	#block-bean-jumpstart-homepage-tall-banner .border-simple img {
 		background-color: $rich_clr-header-bkg;
+	}
+	.site-main-menu {
+	    .navbar .nav > .active > a, 
+	    .navbar .nav > .active > a:hover, 
+	    .navbar .nav > .active > a:focus, 
+	    .navbar .nav > li > a:focus, 
+	    .navbar .nav > li > a:hover,
+	    .navbar .nav > .active-trail > a {
+	        color: $rich_clr-page-bkg;
+	        background: $rich_clr-menu-link-border;
+	        border: 0;
+	    }
 	}
 }
 


### PR DESCRIPTION
Yo. @sherakama I think this is actually done and ready to merge. Includes the following: 

Lomita:
[DONE] \* floating navbar
[DONE] \* text color based on theme setting for light/dark or add wells to blocks on home
[DONE] \* add background color to footer region, or remove footer blocks? 
[DONE] \* fix background header image problem - SHEA
[DONE] \* test in all SULight settings

Palm:
[DONE] \* floating navbar
[DONE] \* Remove header background colors and "stripe" effect from each style option
[DONE] \* Make navbar into a color bar that floats on the page
[DONE] \* Banner block should touch navbar on homepage
[DONE] \* test in all SULight settings

Mayfield:
[DONE] \* Style testimonial block and circle image to float in the right place
[DONE] \* test in all SULight settings

Serra:
[DONE] \* floating navbar w/out background
[DONE] \* style two-col block content on home to be bigger font size
[DONE] \* placement of info text block with more margin
[DONE] \* color fixes for main-top region for each style option
[DONE] \* test in all SULight settings

Panama:
[DONE] \* test in all SULight settings
