### PR TITLE
Home Page Layout with Research Projects, Publications, and News

### DIFF
--- a/layouts/stanford_jumpstart_home_mayfield_lab.inc
+++ b/layouts/stanford_jumpstart_home_mayfield_lab.inc
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * @file
  * Homepage layout for Jumpstart Lab.

--- a/layouts/stanford_jumpstart_home_mayfield_lab.inc
+++ b/layouts/stanford_jumpstart_home_mayfield_lab.inc
@@ -1,0 +1,55 @@
+<?php
+/**
+ * @file
+ */
+
+$context = new stdClass();
+$context->disabled = FALSE; /* Edit this to true to make a default context disabled initially */
+$context->api_version = 3;
+$context->name = 'stanford_jumpstart_home_mayfield_lab';
+$context->description = 'Tagline with Research Projects, Recent Publications, and Recent News blocks';
+$context->tag = 'Home Page';
+$context->conditions = array(
+  'path' => array(
+    'values' => array(
+      '<front>' => '<front>',
+    ),
+  ),
+);
+$context->reactions = array(
+  'block' => array(
+    'blocks' => array(
+      'bean-jumpstart-lead-text-with-body' => array(
+        'module' => 'bean',
+        'delta' => 'jumpstart-lead-text-with-body',
+        'region' => 'content_top',
+        'weight' => '-10',
+      ),
+      'bean-homepage-research-projects-block' => array(
+        'module' => 'bean',
+        'delta' => 'homepage-research-projects-block',
+        'region' => 'content_col3-1',
+        'weight' => '-10',
+      ),
+      'views-publications_common-block_4' => array(
+        'module' => 'views',
+        'delta' => 'publications_common-block_4',
+        'region' => 'content_col3-2',
+        'weight' => '-10',
+      ),
+      'views-f73ff55b085ea49217d347de6630cd5a' => array(
+        'module' => 'views',
+        'delta' => 'f73ff55b085ea49217d347de6630cd5a',
+        'region' => 'content_col3-3',
+        'weight' => '-10',
+      ),
+    ),
+  ),
+);
+$context->condition_mode = 0;
+
+// Translatables
+// Included for use with string extractors like potx.
+t('Home Page');
+t('Tagline with Research Projects, Recent Publications, and Recent News blocks');
+

--- a/layouts/stanford_jumpstart_home_mayfield_lab.inc
+++ b/layouts/stanford_jumpstart_home_mayfield_lab.inc
@@ -33,29 +33,29 @@ $context->reactions = array(
         'region' => 'content_top',
         'weight' => '-10',
       ),
-      'bean-homepage-research-projects-block' => array(
+      'bean-jumpstart-lab-homepage-research-' => array(
         'module' => 'bean',
-        'delta' => 'homepage-research-projects-block',
-        'region' => 'content_col3-1',
+        'delta' => 'jumpstart-lab-homepage-research-',
+        'region' => 'content_row3',
         'weight' => '-10',
       ),
-      'views-publications_common-block_4' => array(
+      'views-c02cf3675aaf368953397f4126400552' => array(
         'module' => 'views',
-        'delta' => 'publications_common-block_4',
-        'region' => 'content_col3-2',
-        'weight' => '-10',
+        'delta' => 'c02cf3675aaf368953397f4126400552',
+        'region' => 'content_row3',
+        'weight' => '-9',
       ),
-      'views-f73ff55b085ea49217d347de6630cd5a' => array(
+      'views-stanford_news-block_1' => array(
         'module' => 'views',
-        'delta' => 'f73ff55b085ea49217d347de6630cd5a',
-        'region' => 'content_col3-3',
-        'weight' => '-10',
+        'delta' => 'stanford_news-block_1',
+        'region' => 'content_row3',
+        'weight' => '-8',
       ),
-      'bean-footer-logo-block' => array(
+      'bean-jumpstart-lab-footer-logo-block' => array(
         'module' => 'bean',
-        'delta' => 'footer-logo-block',
+        'delta' => 'jumpstart-lab-footer-logo-block',
         'region' => 'footer',
-        'weight' => '10',
+        'weight' => '-10',
       ),
     ),
   ),

--- a/layouts/stanford_jumpstart_home_mayfield_lab.inc
+++ b/layouts/stanford_jumpstart_home_mayfield_lab.inc
@@ -1,7 +1,7 @@
 <?php
 /**
  * @file
- * Context export for Home Page, which includes Research Projects, Recent Publications, and Recent News blocks. Built for Jumpstart Lab.
+ * Homepage layout for Jumpstart Lab.
  */
 
 $context = new stdClass();

--- a/layouts/stanford_jumpstart_home_mayfield_lab.inc
+++ b/layouts/stanford_jumpstart_home_mayfield_lab.inc
@@ -20,6 +20,12 @@ $context->conditions = array(
 $context->reactions = array(
   'block' => array(
     'blocks' => array(
+      'search-form' => array(
+        'module' => 'search',
+        'delta' => 'form',
+        'region' => 'search_box',
+        'weight' => '-10',
+      ),
       'bean-jumpstart-lead-text-with-body' => array(
         'module' => 'bean',
         'delta' => 'jumpstart-lead-text-with-body',
@@ -43,6 +49,12 @@ $context->reactions = array(
         'delta' => 'f73ff55b085ea49217d347de6630cd5a',
         'region' => 'content_col3-3',
         'weight' => '-10',
+      ),
+      'bean-footer-logo-block' => array(
+        'module' => 'bean',
+        'delta' => 'footer-logo-block',
+        'region' => 'footer',
+        'weight' => '10',
       ),
     ),
   ),

--- a/layouts/stanford_jumpstart_home_mayfield_lab.inc
+++ b/layouts/stanford_jumpstart_home_mayfield_lab.inc
@@ -1,6 +1,7 @@
 <?php
 /**
  * @file
+ * Context export for Home Page, which includes Research Projects, Recent Publications, and Recent News blocks. Built for Jumpstart Lab.
  */
 
 $context = new stdClass();
@@ -52,4 +53,3 @@ $context->condition_mode = 0;
 // Included for use with string extractors like potx.
 t('Home Page');
 t('Tagline with Research Projects, Recent Publications, and Recent News blocks');
-

--- a/layouts/stanford_jumpstart_home_mayfield_lab.inc
+++ b/layouts/stanford_jumpstart_home_mayfield_lab.inc
@@ -39,15 +39,15 @@ $context->reactions = array(
         'region' => 'content_row3',
         'weight' => '-10',
       ),
-      'views-c02cf3675aaf368953397f4126400552' => array(
+      'views-publications_common-block_4' => array(
         'module' => 'views',
-        'delta' => 'c02cf3675aaf368953397f4126400552',
+        'delta' => 'publications_common-block_4',
         'region' => 'content_row3',
         'weight' => '-9',
       ),
-      'views-stanford_news-block_1' => array(
+      'views-f73ff55b085ea49217d347de6630cd5a' => array(
         'module' => 'views',
-        'delta' => 'stanford_news-block_1',
+        'delta' => 'f73ff55b085ea49217d347de6630cd5a',
         'region' => 'content_row3',
         'weight' => '-8',
       ),

--- a/stanford_jumpstart_home.info
+++ b/stanford_jumpstart_home.info
@@ -58,6 +58,14 @@ layout[stanford_jumpstart_home_mayfield_news_events][header_image] = TRUE
 layout[stanford_jumpstart_home_mayfield_news_events][light_dark] = TRUE
 layout[stanford_jumpstart_home_mayfield_news_events][class] = "stanford-jumpstart-home-mayfield"
 
+layout[stanford_jumpstart_home_mayfield_lab][context] = "stanford_jumpstart_home_mayfield_lab"
+layout[stanford_jumpstart_home_mayfield_lab][thumb] = "js-home-mayfield.png"
+layout[stanford_jumpstart_home_mayfield_lab][title] = "Mayfield Lab"
+layout[stanford_jumpstart_home_mayfield_lab][description] = "<ul><li>Lead Text Block</li><li>Research Projects block</li><li>Auto-generated Publications block</li><li>Auto-generated News block</li></ul>"
+layout[stanford_jumpstart_home_mayfield_lab][header_image] = TRUE
+layout[stanford_jumpstart_home_mayfield_lab][light_dark] = TRUE
+layout[stanford_jumpstart_home_mayfield_lab][class] = "stanford-jumpstart-home-mayfield"
+
 layout[stanford_jumpstart_home_serra][context] = "stanford_jumpstart_home_serra"
 layout[stanford_jumpstart_home_serra][thumb] = "js-home-serra.png"
 layout[stanford_jumpstart_home_serra][title] = "Serra"


### PR DESCRIPTION
Hello Shea.  This Context export creates a homepage that looks like this:

![screen shot 2016-10-12 at 2 14 50 pm](https://cloud.githubusercontent.com/assets/4072139/19327912/434c977a-9086-11e6-872f-2700c112eb3d.png)

There is clearly more styling to do, but please let me know if this appears to be on the right track.
