### PR TITLE
Fix up default and upgrade values for big text.

### DIFF
--- a/css/stanford_jumpstart_home_typography.1.6.css
+++ b/css/stanford_jumpstart_home_typography.1.6.css
@@ -1,0 +1,252 @@
+/**
+ * These styles are needed for an upgrade path prior to version 1.7
+ */
+
+ body #main-menu,
+ body #fullwidth-top,
+ body #main,
+ body #footer,
+ body #fullwidth-bottom {
+   font-size: 20px;
+   line-height: 1.4em;
+ }
+
+ .navbar .nav > li > a {
+   font-size: 20px;
+ }
+
+ h1 {
+   font-size: 2.4em;
+   font-weight: 400;
+   letter-spacing: -.5px;
+   line-height: 1.2em;
+ }
+
+ h2 {
+   font-size: 1.6em;
+   line-height: 1.2em;
+   font-weight: 600;
+ }
+
+ h3 {
+   font-size: 1.2em;
+   line-height: 1.2em;
+   margin: 1.2em 0 0.5em;
+ }
+
+ h4 {
+   font-size: 1em;
+   line-height: 1.2em;
+   margin: 1.2em 0 0.5em;
+ }
+
+ a.more-link,
+ .more-link a {
+   font-size: 20px;
+   font-weight: 400;
+ }
+
+ .normal-link h2,
+ h2.normal-link,
+ .normal-link h3,
+ h3.normal-link {
+   font-size: 20px;
+ }
+
+ li {
+   margin-bottom: .6em;
+ }
+
+ @media (max-width: 980px) {
+   h1 {
+     font-size: 2em;
+   }
+ }
+
+ @media (max-width: 767px) {
+   .main {
+     padding-top: 16px;
+   }
+ }
+
+ @media (max-width: 480px) {
+   h1 {
+     font-size: 1.7em;
+   }
+
+   h2 {
+     font-size: 1.3em;
+   }
+
+   h3 {
+     font-size: 1.1em;
+   }
+
+   h4 {
+     font-weight: 400;
+   }
+ }
+ .site-name a,
+ .site-name a:hover {
+   letter-spacing: -0.5px;
+ }
+
+ #site-name,
+ #site-title-first-line,
+ #site-title-second-line,
+ #site-title-line3 {
+   letter-spacing: -.5px;
+ }
+
+ .navbar .btn-navbar {
+   padding: 12px;
+ }
+
+ .dropdown-menu {
+   box-shadow: 0 1px 1px rgba(0, 0, 0, 0.1);
+ }
+
+ @media (max-width: 767px) {
+   .navbar .btn-navbar {
+     margin-top: 6px;
+     margin-left: 6px;
+   }
+ }
+ .sidebar {
+   margin-top: .8em;
+ }
+
+ .sidebar .block-menu h2,
+ .sidebar .block-menu-block h2 {
+   font-size: 1.1em;
+   line-height: 1.3em;
+ }
+
+ .sidebar .block-menu-block a {
+   font-weight: 400;
+ }
+
+ @media (max-width: 767px) {
+   .site-sidebar-first .block,
+   .site-sidebar-second .block {
+     width: 100%;
+   }
+ }
+
+ @media (max-width: 480px) {
+   .sidebar {
+     margin-bottom: 0;
+   }
+ }
+
+ #footer #footer-content .block {
+   font-size: .8em;
+   line-height: 1.4em;
+ }
+
+ @media (max-width: 767px) {
+   #block-bean-jumpstart-footer-contact-block {
+     margin-bottom: 1.4em;
+   }
+
+   #block-bean-jumpstart-footer-social-media-0 {
+     margin-bottom: 1.3em;
+   }
+
+   #block-bean-optional-footer-block {
+     margin-bottom: .5em;
+   }
+ }
+
+ .banner-overlay p {
+   font-size: 1em;
+ }
+
+ .banner-overlay h2,
+ .banner-overlay h3,
+ .banner-overlay h4 {
+   margin-bottom: 0.3em;
+ }
+
+ .well a.more-link,
+ .well .more-link a {
+   font-size: 20px;
+   font-weight: 400;
+ }
+
+ .well .descriptor {
+   font-size: .8em;
+   margin: .2em 0 0;
+ }
+
+ .well h2 {
+   font-size: 1.5em;
+ }
+
+ .view .postcard-left,
+ .view .postcard-left-wrap,
+ .view .postcard-right,
+ .view .postcard-right-wrap {
+   margin-bottom: 0;
+ }
+
+ .view .postcard-left h3,
+ .view .postcard-right h3,
+ .view .postcard-left-wrap h3,
+ .view .postcard-right h3 {
+   margin-bottom: .8em;
+ }
+
+ .well .view .postcard-left h3,
+ .well .view .postcard-right h3,
+ .well .view .postcard-left-wrap h3,
+ .well .view .postcard-right-wrap h3 {
+   margin: .2em 0 .3em;
+ }
+
+ .views-row-lines .views-row {
+   margin-bottom: 1.5em;
+   padding-bottom: 1.3em;
+   padding-right: 1.3em;
+ }
+
+ .views-row-lines .views-row-1 {
+   padding-top: 1.5em;
+   padding-right: 1.3em;
+ }
+
+ .descriptor {
+   letter-spacing: .2px;
+   text-transform: none;
+   line-height: 1.2em;
+   font-size: 1em;
+   margin-bottom: 8px;
+ }
+
+ .descriptor a {
+   font-weight: 400;
+ }
+
+ .caption p {
+   line-height: 1.2em;
+   margin-bottom: 0;
+ }
+
+ .credits {
+   margin-top: 0;
+ }
+
+ .big-text {
+   letter-spacing: 0;
+   font-size: 2.3em;
+ }
+
+ .summary {
+   font-size: 1.5em;
+ }
+
+ @media (max-width: 767px) {
+   .summary {
+     font-size: 1.2em;
+   }
+ }

--- a/css/stanford_jumpstart_home_typography.css
+++ b/css/stanford_jumpstart_home_typography.css
@@ -1,10 +1,10 @@
-body #footer,	
-body #fullwidth-bottom,	
-body #fullwidth-top,	
-body #main,	
-body #main-menu {	
-  font-size: 20px;	
-  line-height: 1.4em;	
+body #footer,
+body #fullwidth-bottom,
+body #fullwidth-top,
+body #main,
+body #main-menu {
+  font-size: 20px;
+  line-height: 1.4em;
 }
 
 .big-text-styles .navbar .nav > li > a {

--- a/css/stanford_jumpstart_home_typography.css
+++ b/css/stanford_jumpstart_home_typography.css
@@ -1,3 +1,12 @@
+body #footer,	
+body #fullwidth-bottom,	
+body #fullwidth-top,	
+body #main,	
+body #main-menu {	
+  font-size: 20px;	
+  line-height: 1.4em;	
+}
+
 .big-text-styles .navbar .nav > li > a {
   font-size: 20px;
 }

--- a/css/stanford_jumpstart_home_typography.css
+++ b/css/stanford_jumpstart_home_typography.css
@@ -1,12 +1,3 @@
-body #footer,
-body #fullwidth-bottom,
-body #fullwidth-top,
-body #main,
-body #main-menu {
-  font-size: 20px;
-  line-height: 1.4em;
-}
-
 .big-text-styles .navbar .nav > li > a {
   font-size: 20px;
 }

--- a/stanford_jumpstart_home.install
+++ b/stanford_jumpstart_home.install
@@ -33,7 +33,7 @@ function stanford_jumpstart_home_install() {
 /**
  * Sets variable for existing sites.
  */
-function stanford_jumpstart_home_update_7001() {
+function stanford_jumpstart_home_update_7100() {
 
   // Grab the raw value previously used and set it in case the site is not
   // on the default setting for the variable.

--- a/stanford_jumpstart_home.install
+++ b/stanford_jumpstart_home.install
@@ -31,6 +31,14 @@ function stanford_jumpstart_home_install() {
 }
 
 /**
+ * Implements hook_uninstall().
+ */
+function stanford_jumpstart_home_uninstall() {
+  variable_del('stanford_jumpstart_home_include_flat_styles');
+  variable_del('stanford_jumpstart_home_enable_legacy_flat_styles');
+}
+
+/**
  * Sets variable for existing sites.
  */
 function stanford_jumpstart_home_update_7100() {

--- a/stanford_jumpstart_home.install
+++ b/stanford_jumpstart_home.install
@@ -37,10 +37,6 @@ function stanford_jumpstart_home_update_7001() {
 
   // Grab the raw value previously used and set it in case the site is not
   // on the default setting for the variable.
-  $raw_value = db_select("variable", "v")
-    ->fields("v", array("value"))
-    ->condition("name", "stanford_jumpstart_home_include_flat_styles")
-    ->execute()
-    ->fetchField();
-  variable_set("stanford_jumpstart_home_include_flat_styles", $raw_value);
+  $original_value = variable_get("stanford_jumpstart_home_include_flat_styles", 0);
+  variable_set("stanford_jumpstart_home_include_flat_styles", $original_value);
 }

--- a/stanford_jumpstart_home.install
+++ b/stanford_jumpstart_home.install
@@ -40,10 +40,10 @@ function stanford_jumpstart_home_update_7100() {
   $is_less_than_one_seven = FALSE;
 
   // Previous version.
-  // Before we blindly run the update try to grab the previous version of the module
-  // if that information is still kicking around in the database. The system table
-  // keeps a serialized version of the .info file that we could use to figure out the
-  // past version as "schema" is unreliable. 
+  // Before we blindly run the update try to grab the previous version of the
+  // module if that information is still kicking around in the database. The
+  // system table keeps a serialized version of the .info file that we could use
+  // to figure out the past version as "schema" is unreliable.
   $info = db_select("system", "s")
     ->fields('s', array('info'))
     ->condition('name', 'stanford_jumpstart_home')
@@ -52,7 +52,7 @@ function stanford_jumpstart_home_update_7100() {
   $info = unserialize($info);
 
   // Grab the previous version and hope to gosh that it is a tag and not the
-  // dev version. If we get a dev version just fail over to assuming >= 1.7. 
+  // dev version. If we get a dev version just fail over to assuming >= 1.7.
   if (isset($info['version'])) {
     $prev_version = $info['version'];
     if ($prev_version !== "7.x-1.x") {
@@ -62,8 +62,8 @@ function stanford_jumpstart_home_update_7100() {
   }
 
   // If the previous version was less than 1.7 we enable legacy styles.
-  // This will enable a legacy stylesheet instead of the new one. Peeps don't 
-  // like us messing with their styles. 
+  // This will enable a legacy stylesheet instead of the new one. Peeps don't
+  // like us messing with their styles.
   if ($is_less_than_one_seven) {
     variable_set('stanford_jumpstart_home_enable_legacy_flat_styles', 1);
   }

--- a/stanford_jumpstart_home.install
+++ b/stanford_jumpstart_home.install
@@ -42,40 +42,6 @@ function stanford_jumpstart_home_uninstall() {
  * Sets variable for existing sites.
  */
 function stanford_jumpstart_home_update_7100() {
-
-  // Version to deprecate at.
-  $baseline = "1.7";
-  $is_less_than_one_seven = FALSE;
-
-  // Previous version.
-  // Before we blindly run the update try to grab the previous version of the
-  // module if that information is still kicking around in the database. The
-  // system table keeps a serialized version of the .info file that we could use
-  // to figure out the past version as "schema" is unreliable.
-  $info = db_select("system", "s")
-    ->fields('s', array('info'))
-    ->condition('name', 'stanford_jumpstart_home')
-    ->execute()
-    ->fetchField();
-  $info = unserialize($info);
-
-  // Grab the previous version and hope to gosh that it is a tag and not the
-  // dev version. If we get a dev version just fail over to assuming >= 1.7.
-  if (isset($info['version'])) {
-    $prev_version = $info['version'];
-    if ($prev_version !== "7.x-1.x") {
-      $normalized_version = str_replace("7.x-", "", $prev_version);
-      $is_less_than_one_seven = version_compare($normalized_version, $baseline, "<");
-    }
-  }
-
-  // If the previous version was less than 1.7 we enable legacy styles.
-  // This will enable a legacy stylesheet instead of the new one. Peeps don't
-  // like us messing with their styles.
-  if ($is_less_than_one_seven) {
-    variable_set('stanford_jumpstart_home_enable_legacy_flat_styles', 1);
-  }
-
   // Grab the raw value previously used and set it in case the site is not
   // on the default setting for the variable.
   $original_value = variable_get("stanford_jumpstart_home_include_flat_styles", 0);

--- a/stanford_jumpstart_home.install
+++ b/stanford_jumpstart_home.install
@@ -34,5 +34,13 @@ function stanford_jumpstart_home_install() {
  * Sets variable for existing sites.
  */
 function stanford_jumpstart_home_update_7001() {
-  // Removed for legacy reasons.
+
+  // Grab the raw value previously used and set it in case the site is not
+  // on the default setting for the variable.
+  $raw_value = db_select("variable", "v")
+    ->fields("v", array("value"))
+    ->condition("name", "stanford_jumpstart_home_include_flat_styles")
+    ->execute()
+    ->fetchField();
+  variable_set("stanford_jumpstart_home_include_flat_styles", $raw_value);
 }

--- a/stanford_jumpstart_home.install
+++ b/stanford_jumpstart_home.install
@@ -40,6 +40,10 @@ function stanford_jumpstart_home_update_7100() {
   $is_less_than_one_seven = FALSE;
 
   // Previous version.
+  // Before we blindly run the update try to grab the previous version of the module
+  // if that information is still kicking around in the database. The system table
+  // keeps a serialized version of the .info file that we could use to figure out the
+  // past version as "schema" is unreliable. 
   $info = db_select("system", "s")
     ->fields('s', array('info'))
     ->condition('name', 'stanford_jumpstart_home')
@@ -48,7 +52,7 @@ function stanford_jumpstart_home_update_7100() {
   $info = unserialize($info);
 
   // Grab the previous version and hope to gosh that it is a tag and not the
-  // dev version.
+  // dev version. If we get a dev version just fail over to assuming >= 1.7. 
   if (isset($info['version'])) {
     $prev_version = $info['version'];
     if ($prev_version !== "7.x-1.x") {
@@ -58,6 +62,8 @@ function stanford_jumpstart_home_update_7100() {
   }
 
   // If the previous version was less than 1.7 we enable legacy styles.
+  // This will enable a legacy stylesheet instead of the new one. Peeps don't 
+  // like us messing with their styles. 
   if ($is_less_than_one_seven) {
     variable_set('stanford_jumpstart_home_enable_legacy_flat_styles', 1);
   }

--- a/stanford_jumpstart_home.install
+++ b/stanford_jumpstart_home.install
@@ -35,6 +35,33 @@ function stanford_jumpstart_home_install() {
  */
 function stanford_jumpstart_home_update_7100() {
 
+  // Version to deprecate at.
+  $baseline = "1.7";
+  $is_less_than_one_seven = FALSE;
+
+  // Previous version.
+  $info = db_select("system", "s")
+    ->fields('s', array('info'))
+    ->condition('name', 'stanford_jumpstart_home')
+    ->execute()
+    ->fetchField();
+  $info = unserialize($info);
+
+  // Grab the previous version and hope to gosh that it is a tag and not the
+  // dev version.
+  if (isset($info['version'])) {
+    $prev_version = $info['version'];
+    if ($prev_version !== "7.x-1.x") {
+      $normalized_version = str_replace("7.x-", "", $prev_version);
+      $is_less_than_one_seven = version_compare($normalized_version, $baseline, "<");
+    }
+  }
+
+  // If the previous version was less than 1.7 we enable legacy styles.
+  if ($is_less_than_one_seven) {
+    variable_set('stanford_jumpstart_home_enable_legacy_flat_styles', 1);
+  }
+
   // Grab the raw value previously used and set it in case the site is not
   // on the default setting for the variable.
   $original_value = variable_get("stanford_jumpstart_home_include_flat_styles", 0);

--- a/stanford_jumpstart_home.install
+++ b/stanford_jumpstart_home.install
@@ -9,7 +9,6 @@
  * Implements hook_install().
  */
 function stanford_jumpstart_home_install() {
-  variable_set('stanford_jumpstart_home_include_flat_styles', 1);
   variable_set('stanford_jumpstart_home_active', 'stanford_jumpstart_home_palm');
   variable_set("stanford_jumpstart_home_default_header_image", drupal_get_path("module", "stanford_jumpstart_home") . "/img/header-background-default.jpg");
 
@@ -35,5 +34,5 @@ function stanford_jumpstart_home_install() {
  * Sets variable for existing sites.
  */
 function stanford_jumpstart_home_update_7001() {
-  variable_set('stanford_jumpstart_home_include_flat_styles', 0);
+  // Removed for legacy reasons.
 }

--- a/stanford_jumpstart_home.module
+++ b/stanford_jumpstart_home.module
@@ -414,7 +414,7 @@ function stanford_jumpstart_home_process_file_managed($element, &$form_state, $f
  * Implements hook_preprocess_html().
  */
 function stanford_jumpstart_home_preprocess_html(&$vars) {
-  if (variable_get('stanford_jumpstart_home_include_flat_styles', 0)) {
+  if (variable_get('stanford_jumpstart_home_include_flat_styles', 1)) {
     drupal_add_css(drupal_get_path('module', 'stanford_jumpstart_home') . '/css/stanford_jumpstart_home_typography.css');
     $vars['classes_array'][] = 'big-text-styles';
   }

--- a/stanford_jumpstart_home.module
+++ b/stanford_jumpstart_home.module
@@ -416,16 +416,20 @@ function stanford_jumpstart_home_process_file_managed($element, &$form_state, $f
 function stanford_jumpstart_home_preprocess_html(&$vars) {
 
   // Enable big text styles for version 1.7 and after.
+  // Because of the drastic change in versions 1.6 and 1.7 this upgrade path
+  // addition has been added. New sites 1.7 and after get the new stylesheet and
+  // pervious to version 1.7 sites can opt out of the legacy one.
   if (variable_get('stanford_jumpstart_home_include_flat_styles', 1) && !variable_get('stanford_jumpstart_home_enable_legacy_flat_styles', 0)) {
     drupal_add_css(drupal_get_path('module', 'stanford_jumpstart_home') . '/css/stanford_jumpstart_home_typography.css');
     $vars['classes_array'][] = 'big-text-styles';
   }
 
-  // Legacy condition for those upgrading from less than version 1.7.
+  // Legacy condition for those upgrading from less than version 1.7. For when
+  // a site was using 1.6 or less and relied on the styles as they were. We also
+  // do not add the body class for big-text-styles in the legacy version.
   if (variable_get('stanford_jumpstart_home_include_flat_styles', 1) && variable_get('stanford_jumpstart_home_enable_legacy_flat_styles', 0)) {
     drupal_add_css(drupal_get_path('module', 'stanford_jumpstart_home') . '/css/stanford_jumpstart_home_typography.1.6.css');
   }
-
 
   $context_name = variable_get('stanford_jumpstart_home_active', '');
 

--- a/stanford_jumpstart_home.module
+++ b/stanford_jumpstart_home.module
@@ -303,6 +303,8 @@ function stanford_jumpstart_homepage_dashboard_form($form, $form_state) {
     '#type' => 'checkbox',
     '#title' => t('Include BIG text'),
     '#weight' => 9998,
+    // Yes, the variable is named "stanford_jumpstart_home_include_flat_styles",
+    // and the UI option is "Include BIG text"
     '#default_value' => variable_get('stanford_jumpstart_home_include_flat_styles', 1),
   );
 

--- a/stanford_jumpstart_home.module
+++ b/stanford_jumpstart_home.module
@@ -414,10 +414,18 @@ function stanford_jumpstart_home_process_file_managed($element, &$form_state, $f
  * Implements hook_preprocess_html().
  */
 function stanford_jumpstart_home_preprocess_html(&$vars) {
-  if (variable_get('stanford_jumpstart_home_include_flat_styles', 1)) {
+
+  // Enable big text styles for version 1.7 and after.
+  if (variable_get('stanford_jumpstart_home_include_flat_styles', 1) && !variable_get('stanford_jumpstart_home_enable_legacy_flat_styles', 0)) {
     drupal_add_css(drupal_get_path('module', 'stanford_jumpstart_home') . '/css/stanford_jumpstart_home_typography.css');
     $vars['classes_array'][] = 'big-text-styles';
   }
+
+  // Legacy condition for those upgrading from less than version 1.7.
+  if (variable_get('stanford_jumpstart_home_include_flat_styles', 1) && variable_get('stanford_jumpstart_home_enable_legacy_flat_styles', 0)) {
+    drupal_add_css(drupal_get_path('module', 'stanford_jumpstart_home') . '/css/stanford_jumpstart_home_typography.1.6.css');
+  }
+
 
   $context_name = variable_get('stanford_jumpstart_home_active', '');
 

--- a/stanford_jumpstart_home.module
+++ b/stanford_jumpstart_home.module
@@ -419,6 +419,9 @@ function stanford_jumpstart_home_preprocess_html(&$vars) {
   // Because of the drastic change in versions 1.6 and 1.7 this upgrade path
   // addition has been added. New sites 1.7 and after get the new stylesheet and
   // pervious to version 1.7 sites can opt out of the legacy one.
+  // Why is the variable for BIG text styles named stanford_jumpstart_home_include_flat_styles?
+  // Nobody knows. But stanford_jumpstart_home_include_flat_styles enables the
+  // BIG text styles.
   if (variable_get('stanford_jumpstart_home_include_flat_styles', 1) && !variable_get('stanford_jumpstart_home_enable_legacy_flat_styles', 0)) {
     drupal_add_css(drupal_get_path('module', 'stanford_jumpstart_home') . '/css/stanford_jumpstart_home_typography.css');
     $vars['classes_array'][] = 'big-text-styles';
@@ -427,6 +430,10 @@ function stanford_jumpstart_home_preprocess_html(&$vars) {
   // Legacy condition for those upgrading from less than version 1.7. For when
   // a site was using 1.6 or less and relied on the styles as they were. We also
   // do not add the body class for big-text-styles in the legacy version.
+  // stanford_jumpstart_home_include_flat_styles means that the user has chosen
+  // "Include BIG text" in the UI. stanford_jumpstart_home_enable_legacy_flat_styles
+  // is the setting indicating that they chose that option in 1.6, and 1.6 only.
+  // Whew.
   if (variable_get('stanford_jumpstart_home_include_flat_styles', 1) && variable_get('stanford_jumpstart_home_enable_legacy_flat_styles', 0)) {
     drupal_add_css(drupal_get_path('module', 'stanford_jumpstart_home') . '/css/stanford_jumpstart_home_typography.1.6.css');
   }


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Changes the upgrade path for BigText on migrations
- Previously, sites on the Sites Platform could have appeared to have had big-text enabled but not as the form value was defaulted to on but the page attachment was defaulted to off. Unless the configuration form was submitted the default values would take place and there would be a mismatch in the appearance of configuration. This corrects the offset default values and removes the disabling of bigtext as an upgrade path so that the correct values are used after running 

# Needed By (Date)
- Sometime in the near future.

# Urgency
- 5/10

# Steps to Test

Test sites: 
```
- ds_jumpstart-aistudy                        7.x-1.0
- ds_sws-products                               7.x-1.1
- ds_academicstaffhandbook             7.x-1.2
- ds_cas                                                7.x-1.4
- ds_sws-paragraphs                  7.x-1.4-dev
- ds_morrison                                        7.x-1.5
- ds_religious-studies                          7.x-1.6
- ds_roberts-lab                                   7.x-1.7
- ds_jumpstart-aimi                             7.x-1.x
```
1. Clone site to local or push up a branch to ACSF dev with this branch of the module in it.
2. Validate that the `big-text-styles` class is not on the <body> element of the home page.
3. Validate that the `big text` option is enabled in the customize design options `drush vget stanford_jumpstart_home_include_flat_styles`
4. Check out this branch
5. Run drush updb -y

*For sites on version 1.5 and below:*
- Validate that big-text styles are disabled.
- Validate that when enabled, it uses the legacy stylesheet.

*For sites on version 1.6*
- Validate that big text styles stay enabled and the legacy stylesheet is used without a css body class.

*For sites on version 1.7 and above*
- Validate that big text stays enabled and the default stylesheet is used

# Affected Projects or Products
- All migrations

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)