### PR TITLE
SITES-837: Set stanford_jumpstart_home_mayfield_lab to be disabled by default

### DIFF
--- a/layouts/stanford_jumpstart_home_mayfield_lab.inc
+++ b/layouts/stanford_jumpstart_home_mayfield_lab.inc
@@ -6,7 +6,7 @@
  */
 
 $context = new stdClass();
-$context->disabled = FALSE; /* Edit this to true to make a default context disabled initially */
+$context->disabled = TRUE; // Disable by default
 $context->api_version = 3;
 $context->name = 'stanford_jumpstart_home_mayfield_lab';
 $context->description = 'Tagline with Research Projects, Recent Publications, and Recent News blocks';


### PR DESCRIPTION
# Steps to Test
1. Build a JSL site with this branch
2. Ensure that stanford_jumpstart_home_mayfield_lab is enabled at install time